### PR TITLE
[ISSUE #96] Mac version not correctly bundled

### DIFF
--- a/ZombustersMac.sln
+++ b/ZombustersMac.sln
@@ -20,4 +20,10 @@ Global
 		{43927F95-03CB-4EB3-8AB9-BF98CA118484}.DemoDebug|Any CPU.ActiveCfg = Debug|Any CPU
 		{43927F95-03CB-4EB3-8AB9-BF98CA118484}.DemoDebug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.DotNetNamingPolicy = $1
+		$1.DirectoryNamespaceAssociation = PrefixedHierarchical
+		version = 1.2.0
+	EndGlobalSection
 EndGlobal

--- a/ZombustersWindows/Localization/Strings.Designer.cs
+++ b/ZombustersWindows/Localization/Strings.Designer.cs
@@ -39,7 +39,11 @@ namespace ZombustersWindows.Localization {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
+#if WINDOWS
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ZombustersWindows.Localization.Strings", typeof(Strings).Assembly);
+#elif NETCOREAPP
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("ZombustersMac.Localization.Strings", typeof(Strings).Assembly);
+#endif
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/ZombustersWindows/ZombustersMac.csproj
+++ b/ZombustersWindows/ZombustersMac.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <OutputType>WinExe</OutputType>
+        <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp2.2</TargetFramework>
+        <ReleaseVersion>1.2.0</ReleaseVersion>
+        <ApplicationIcon>Game.ico</ApplicationIcon>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -32,13 +34,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="GameAnalytics.Mono.SDK" Version="3.0.8" />
+        <PackageReference Include="GameAnalytics.Mono.SDK" Version="3.1.0" />
+        <PackageReference Include="NLog" Version="4.7.5" />
+        <PackageReference Include="Bugsnag" Version="2.2.1" />
+        <PackageReference Include="Facepunch.Steamworks" Version="2.3.3" />
         <PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
         <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" />
-        <PackageReference Include="NLog" Version="4.6.8" />
-        <PackageReference Include="Bugsnag" Version="2.2.0" />
-        <PackageReference Include="Facepunch.Steamworks" Version="2.3.3" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.1.189" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ZombustersWindows/ZombustersMac.csproj
+++ b/ZombustersWindows/ZombustersMac.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3</TargetFramework>
         <ReleaseVersion>1.2.0</ReleaseVersion>
         <ApplicationIcon>Game.ico</ApplicationIcon>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-      <IntermediateOutputPath>obj\Debug\netcoreapp2.2</IntermediateOutputPath>
+      <IntermediateOutputPath>obj\Debug\netcoreapp3</IntermediateOutputPath>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
       <DebugType></DebugType>
@@ -17,30 +17,36 @@
       <IntermediateOutputPath>obj\Demo</IntermediateOutputPath>
       <DebugType></DebugType>
       <Optimize>true</Optimize>
-      <OutputPath>bin\Demo\netcoreapp2.2</OutputPath>
-      <DefineConstants>TRACE;DEMO;NETCOREAPP;NETCOREAPP2_2</DefineConstants>
+      <OutputPath>bin\Demo\netcoreapp3</OutputPath>
+      <DefineConstants>TRACE;DEMO;NETCOREAPP;NETCOREAPP3</DefineConstants>
       <NoWarn>1701;1702</NoWarn>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DemoDebug|AnyCPU' ">
-      <IntermediateOutputPath>obj\DemoDebug\netcoreapp2.2</IntermediateOutputPath>
+      <IntermediateOutputPath>obj\DemoDebug\netcoreapp3</IntermediateOutputPath>
       <DebugSymbols>true</DebugSymbols>
       <Optimize>false</Optimize>
-      <OutputPath>bin\DemoDebug\netcoreapp2.2</OutputPath>
-      <DefineConstants>TRACE;DEMO;NETCOREAPP;NETCOREAPP2_2</DefineConstants>
+      <OutputPath>bin\DemoDebug\netcoreapp3</OutputPath>
+      <DefineConstants>TRACE;DEMO;NETCOREAPP;NETCOREAPP3</DefineConstants>
       <NoStdLib>true</NoStdLib>
     </PropertyGroup>
+    
+    <PropertyGroup>
+        <CFBundleShortVersionString>1.2.0</CFBundleShortVersionString>
+    </PropertyGroup>
+    
     <ItemGroup>
         <MonoGameContentReference Include="**\*.mgcb" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="GameAnalytics.Mono.SDK" Version="3.1.0" />
         <PackageReference Include="NLog" Version="4.7.5" />
         <PackageReference Include="Bugsnag" Version="2.2.1" />
         <PackageReference Include="Facepunch.Steamworks" Version="2.3.3" />
         <PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
         <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.7.1.189" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" />
+        <PackageReference Include="Dotnet.Bundle" Version="0.9.13" />
+        <PackageReference Include="GameAnalytics.Net.Core.SDK" Version="3.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ZombustersWindows/ZombustersMac.csproj
+++ b/ZombustersWindows/ZombustersMac.csproj
@@ -43,7 +43,7 @@
         <PackageReference Include="Bugsnag" Version="2.2.1" />
         <PackageReference Include="Facepunch.Steamworks" Version="2.3.3" />
         <PackageReference Include="MonoGame.Content.Builder" Version="3.7.0.9" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.7.1.189" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
         <PackageReference Include="MonoGame.Framework.DesktopGL.Core" Version="3.8.0.2" />
         <PackageReference Include="Dotnet.Bundle" Version="0.9.13" />
         <PackageReference Include="GameAnalytics.Net.Core.SDK" Version="3.1.0" />


### PR DESCRIPTION
We have created the Mac version to be distributed

Upgraded:

- Monogame 3.8
- Netcore 3